### PR TITLE
Confluent Schema Registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,34 @@ public class KafkaMapperProvider implements KafkaObjectMapperProvider {
 Do not forget to register implementation in a service file named
 `com.kumuluz.ee.streaming.kafka.utils.KafkaObjectMapperProvider`.
 
+## Schema Registry Support
+You can configure schema registry for Serialization and Deserialization simply by adding the relavant configuration properties to the consumer and producer:
+
+```yaml
+kumuluzee:
+  streaming:
+    kafka:
+      consumer-avro:
+        bootstrap-servers: localhost:29092
+        group-id: group1
+        enable-auto-commit: true
+        auto-offset-reset: latest
+        key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
+        schema-registry-url: http://localhost:8081
+        specific-avro-reader: true
+      producer-avro:
+        bootstrap-servers: localhost:29092
+        key-serializer: org.apache.kafka.common.serialization.StringSerializer
+        value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
+        schema-registry-url: http://localhost:8081
+        auto-register-schemas: false
+```
+
+For full sample with Kafka and Schema Registry you should check out [kumuluzee-samples](https://github.com/kumuluz/kumuluzee-samples) repository, module `kumuluzee-streaming-kafka-registry`.
+
+__NOTE: Json Serializer and Deserializer provided by this extension do not support Schema Registry! Use the Confluent or other 3rd party provided SerDes.__
+
 ### Disabling extension
 
 The extension can be disabled by setting the `kumuluzee.streaming.kafka.enabled` configuration property to `false`. This

--- a/common/src/main/java/com/kumuluz/ee/streaming/common/config/ConfigLoader.java
+++ b/common/src/main/java/com/kumuluz/ee/streaming/common/config/ConfigLoader.java
@@ -50,15 +50,15 @@ public class ConfigLoader {
         }
 
         Map<String, Object> prop = new HashMap<>();
-        for (String configProp : configProps) {
+        for (String configPropDashed : configProps) {
             try {
-                String configPropKumuluz = configProp.replace('.', '-');
-                String configName = configPrefix + "." + configPropKumuluz;
+                String configPropDotted = configPropDashed.replace('-', '.');
+                String configName = configPrefix + "." + configPropDashed;
 
-                if (overridesMap.containsKey(configPropKumuluz)) {
-                    prop.put(configProp, overridesMap.get(configPropKumuluz));
+                if (overridesMap.containsKey(configPropDashed)) {
+                    prop.put(configPropDotted, overridesMap.get(configPropDashed));
                 } else if (confUtil.get(configName).isPresent()) {
-                    prop.put(configProp, confUtil.get(configName).get());
+                    prop.put(configPropDotted, confUtil.get(configName).get());
                 }
             } catch (Exception e) {
                 log.severe("Unable to read configuration " + configPrefix + ": " + e.toString());

--- a/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/config/KafkaConsumerConfigLoader.java
+++ b/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/config/KafkaConsumerConfigLoader.java
@@ -21,6 +21,7 @@
 
 package com.kumuluz.ee.streaming.kafka.config;
 
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.streaming.common.annotations.ConfigurationOverride;
 import com.kumuluz.ee.streaming.common.config.ConfigLoader;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -40,9 +41,8 @@ public class KafkaConsumerConfigLoader {
     private final static String CONFIG_PREFIX = "kumuluzee.streaming.kafka";
 
     public static Map<String, Object> getConfig(String configName, ConfigurationOverride[] overrides) {
-        List<String> configNames = new LinkedList<>();
-        ConsumerConfig.configNames().iterator().forEachRemaining(configNames::add);
-        configNames.addAll(KumuluzEeCustomConfig.getCustomConfigs());
+        List<String> configNames = ConfigurationUtil.getInstance().getMapKeys(CONFIG_PREFIX + "." + configName)
+            .orElse(new LinkedList<>());
 
         return ConfigLoader.getConfig(configNames,
                 CONFIG_PREFIX + "." + configName,

--- a/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/config/KafkaProducerConfigLoader.java
+++ b/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/config/KafkaProducerConfigLoader.java
@@ -21,6 +21,7 @@
 
 package com.kumuluz.ee.streaming.kafka.config;
 
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.streaming.common.annotations.ConfigurationOverride;
 import com.kumuluz.ee.streaming.common.config.ConfigLoader;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -40,9 +41,8 @@ public class KafkaProducerConfigLoader {
     private final static String CONFIG_PREFIX = "kumuluzee.streaming.kafka";
 
     public static Map<String, Object> getConfig(String configName, ConfigurationOverride[] overrides) {
-        List<String> configNames = new LinkedList<>();
-        ProducerConfig.configNames().iterator().forEachRemaining(configNames::add);
-        configNames.addAll(KumuluzEeCustomConfig.getCustomConfigs());
+        List<String> configNames = ConfigurationUtil.getInstance().getMapKeys(CONFIG_PREFIX + "." + configName)
+            .orElse(new LinkedList<>());
 
         return ConfigLoader.getConfig(configNames,
                 CONFIG_PREFIX + "." + configName,

--- a/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/config/KafkaStreamsConfigLoader.java
+++ b/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/config/KafkaStreamsConfigLoader.java
@@ -20,6 +20,7 @@
  */
 package com.kumuluz.ee.streaming.kafka.config;
 
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.streaming.common.annotations.ConfigurationOverride;
 import com.kumuluz.ee.streaming.common.config.ConfigLoader;
 import org.apache.kafka.streams.StreamsConfig;
@@ -39,9 +40,8 @@ public class KafkaStreamsConfigLoader {
     private final static String CONFIG_PREFIX = "kumuluzee.streaming.kafka";
 
     public static Map<String, Object> getConfig(String configName, ConfigurationOverride[] overrides) {
-        List<String> configNames = new LinkedList<>();
-        StreamsConfig.configDef().names().iterator().forEachRemaining(configNames::add);
-        configNames.addAll(KumuluzEeCustomStreamsConfig.getCustomConfigs());
+        List<String> configNames = ConfigurationUtil.getInstance().getMapKeys(CONFIG_PREFIX + "." + configName)
+            .orElse(new LinkedList<>());
 
         return ConfigLoader.getConfig(configNames,
                 CONFIG_PREFIX + "." + configName,

--- a/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/utils/consumer/KafkaConsumerFactory.java
+++ b/kafka/src/main/java/com/kumuluz/ee/streaming/kafka/utils/consumer/KafkaConsumerFactory.java
@@ -160,7 +160,9 @@ public class KafkaConsumerFactory implements ConsumerFactory<ConsumerRunnable> {
                 Class valueSerializer = Class.forName(valueTypeConfig);
                 Type t = ValidationUtils.getSerializerType(valueSerializer, false);
 
-                if (!(t instanceof TypeVariable) && !((Class<?>)valueType).isAssignableFrom((Class<?>) t)) {
+                //Some Confluent serializers use Object instead of generic T
+                if (!(t instanceof TypeVariable) && !((Class<?>)valueType).isAssignableFrom((Class<?>) t)
+                    && !Object.class.equals(t)) {
                     log.severe("Value serializer type does not match the StreamListener parameter type.");
                     return false;
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
 
         <kumuluzee.version>3.0.0</kumuluzee.version>
 
-        <kafka-clients.version>2.1.0</kafka-clients.version>
-        <kafka-streams.version>2.1.0</kafka-streams.version>
+        <kafka-clients.version>2.5.0</kafka-clients.version>
+        <kafka-streams.version>2.5.0</kafka-streams.version>
 
         <jaxb-api.version>2.3.0</jaxb-api.version>
 


### PR DESCRIPTION
Additional consumer/producer properties need to be configured to use schema registry. Current implementation used a whitelist approach to load the configuration using the apache consumer and producer property keys. This was removed and now all config keys are loaded, known or unknown. Added documentation and sample to kumuluzee-samples.