### PR TITLE
Update kafka clients and kafka streams version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
 
         <kumuluzee.version>3.11.0</kumuluzee.version>
 
-        <kafka-clients.version>2.6.0</kafka-clients.version>
-        <kafka-streams.version>2.6.0</kafka-streams.version>
+        <kafka-clients.version>2.8.1</kafka-clients.version>
+        <kafka-streams.version>2.8.1</kafka-streams.version>
 
         <jaxb-api.version>2.3.1</jaxb-api.version>
 


### PR DESCRIPTION
The current kafka client version (2.6.0) is more than year old. It would be great to update it to a newer non API breaking version. In this case to 2.8.1.